### PR TITLE
Use Java 17 when building qodat-api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.internal.os.OperatingSystem
 plugins {
     id("org.openjfx.javafxplugin") version "0.0.11"
     id("org.beryx.runtime") version "1.12.7"
-    kotlin("jvm") version "1.6.0"
+    kotlin("jvm") version "1.7.10"
     kotlin("plugin.serialization") version "1.6.0"
     application
 }

--- a/qodat-api/build.gradle.kts
+++ b/qodat-api/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
     }
 }
 
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}
+
 sourceSets {
     named("main") {
         java.srcDir("src/main/kotlin")


### PR DESCRIPTION
Previously we weren't specifying a JVM version target for `qodat-api`. This was causing a mix of Java versions getting used.

I also updated the Kotlin JVM plugin to the latest version.