### PR TITLE
Remove JitPack repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ version = "0.1.8"
 
 repositories {
     maven(url = "https://repo.runelite.net")
-    maven(url = "https://jitpack.io")
     mavenCentral()
     jcenter()
 }


### PR DESCRIPTION
This repo was timing out during builds and causing gradle to exit with a
spurious failure.